### PR TITLE
Persist settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 hack.dpp.hwsampler.xrnx
 *.pdf
+preferences.xml

--- a/func.lua
+++ b/func.lua
@@ -1,5 +1,7 @@
 require"util"
 require"midi"
+require"prefs"
+
 
 -- global options box
 OPTIONS = {
@@ -19,6 +21,7 @@ OPTIONS = {
   between_time = 100
 }
 
+
 TAGS = {[0]="Bass", "Drum", "FX", "Keys", "Lead", "Pad", "Strings",  "Vocal"}
 NOTES = {[0]="C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"}
 
@@ -28,18 +31,19 @@ C_NOT_PRESSED = {20, 20, 20}
 
 -- state
 STATE = {
-  midi_device = nil, -- current midi device name
-  dev = nil,         -- current midi device object
-  recording = false, -- are we actively recording
-  notes = nil,       -- list of notes to send to the midi device
-  notei = nil,       -- current index in note list
-  layers = nil,      -- number of velocity layers for each note
-  layeri = nil,      -- current layer
-  rrobin = nil,      -- number of round robin layers for each note
-  rrobini = nil,     -- current round robin layer
-  total = nil,       -- total amount of notes that will be sampled
-  inst = nil,        -- instrument to which samples will be saved
-  inst_index = nil   -- instrument index
+  midi_device = nil,    -- current midi device name
+  dev = nil,            -- current midi device object
+  midi_device_index = 1,-- current midi device selected in options list
+  recording = false,    -- are we actively recording
+  notes = nil,          -- list of notes to send to the midi device
+  notei = nil,          -- current index in note list
+  layers = nil,         -- number of velocity layers for each note
+  layeri = nil,         -- current layer
+  rrobin = nil,         -- number of round robin layers for each note
+  rrobini = nil,        -- current round robin layer
+  total = nil,          -- total amount of notes that will be sampled
+  inst = nil,           -- instrument to which samples will be saved
+  inst_index = nil      -- instrument index
 }
 
 -- reset state to be ready to record

--- a/gui.lua
+++ b/gui.lua
@@ -1,8 +1,10 @@
 require"func"
 require"crunch"
+require"prefs"
 
 vb = nil
 WINDOW = nil
+prefs = Prefs:new()
 DEFAULT_MARGIN = renoise.ViewBuilder.DEFAULT_CONTROL_MARGIN
 UNIT = renoise.ViewBuilder.DEFAULT_CONTROL_HEIGHT
 
@@ -79,6 +81,7 @@ function tag_matrix()
 end
 
 function midi_list()
+  print("midi_device_index: ", STATE.midi_device_index)
   return vb:horizontal_aligner {
     margin = DEFAULT_MARGIN,
     spacing = 1,
@@ -90,6 +93,7 @@ function midi_list()
     vb:popup {
       width = "50%",
       items = renoise.Midi.available_output_devices(),
+      value = STATE.midi_device_index,
       notifier = select_midi_device,
       tooltip = "MIDI device to send MIDI signals to."
     },
@@ -367,7 +371,8 @@ function show_menu()
     }
   }
 
-  select_midi_device(1)
+  -- load the saved midi device. Default to device 1 if a preference doesn't exist
+  select_midi_device(prefs:read('midi_device_index'), 1)
 
   WINDOW = renoise.app():show_custom_dialog(
     title, content

--- a/midi.lua
+++ b/midi.lua
@@ -6,8 +6,11 @@ ALL_NOTE_OFF_1 = 0xB0
 ALL_NOTE_OFF_2 = 0x7B
 
 -- get midi device name
-function select_midi_device(dev)
-  STATE.midi_device = renoise.Midi.available_output_devices()[dev]
+function select_midi_device(dev_index)
+  STATE.midi_device = renoise.Midi.available_output_devices()[dev_index]
+  STATE.midi_device_index = dev_index
+  prefs:write("midi_device_index", dev_index)
+  
   print("Selected device: "..STATE.midi_device)
 end
 

--- a/prefs.lua
+++ b/prefs.lua
@@ -18,7 +18,7 @@ Prefs = {}
   
   -- reads saved preferences. 
   -- default argument required and is used (and saved) if
-  -- the prefernce doesn't exist
+  -- the preference doesn't exist
   function Prefs:read(pref, default)
     local value = nil
     
@@ -34,7 +34,7 @@ Prefs = {}
   
   -- writes or updates prefernces for later recall
   function Prefs:write(pref, value)
-    -- if the setting exists, update it's value
+    -- if the setting exists, update its value
     if self.options[tostring(pref)] then
       self.options[tostring(pref)].value = value
     -- if the settind doesn't exist yet, save it.

--- a/prefs.lua
+++ b/prefs.lua
@@ -1,0 +1,44 @@
+Prefs = {}
+  -- return a new Prefs instance
+  -- kicks off all the Renoise preference tooling and 
+  -- loads stored preferences into the global STATE
+  function Prefs:new()
+    
+    self.options = renoise.Document.create("HWSamplerPreferences") {
+      midi_device_index = 1
+    }
+    
+    renoise.tool().preferences = self.options
+    
+    -- load options into state
+    STATE.midi_device_index = self.options.midi_device_index.value
+    
+    return self
+  end
+  
+  -- reads saved preferences. 
+  -- default argument required and is used (and saved) if
+  -- the prefernce doesn't exist
+  function Prefs:read(pref, default)
+    local value = nil
+    
+    if self.options[tostring(pref)] then
+      value = self.options[tostring(pref)].value
+    else
+      self:write(pref, default)
+      value = default
+    end
+      
+    return value
+  end
+  
+  -- writes or updates prefernces for later recall
+  function Prefs:write(pref, value)
+    -- if the setting exists, update it's value
+    if self.options[tostring(pref)] then
+      self.options[tostring(pref)].value = value
+    -- if the settind doesn't exist yet, save it.
+    else
+      self.options[tostring(pref)] = value
+    end
+  end


### PR DESCRIPTION
Hi Verdog. This PR adds preference support to the tool. Putting it to use, it can currently save last midi device chosen. Of course, this can easily be worked throughout the app. Cheers!