### PR TITLE
Fixed bug where tool would crash if saved preference of MIDI device i…

### DIFF
--- a/func.lua
+++ b/func.lua
@@ -50,7 +50,6 @@ STATE = {
 function reset_state()
   STATE.notei = nil
   STATE.notes = nil
-  STATE.dev = nil
   STATE.recording = false
   STATE.layers = nil
   STATE.layeri = nil
@@ -59,6 +58,8 @@ function reset_state()
   STATE.total = nil
   STATE.inst = nil
   STATE.inst_index = nil
+  
+  reset_midi_device_state()
   
   TOCALL = nil -- from util.lua
   KILL = false -- from util.lua
@@ -72,6 +73,16 @@ function reset_state()
     renoise.tool():remove_timer(stop_note)
   end
 end
+
+function reset_midi_device_state()
+  local index = 1
+  local device_name = renoise.Midi.available_output_devices()[index]
+
+  STATE.dev = device_name
+  STATE.midi_device = nil
+  STATE.midi_device_index = index
+end
+renoise.Midi.devices_changed_observable(reset_midi_device_state())
 
 -- toggles the on/off state of a button
 function toggle_button(button, ttype)

--- a/gui.lua
+++ b/gui.lua
@@ -97,7 +97,9 @@ function midi_list()
       width = "50%",
       items = renoise.Midi.available_output_devices(),
       value = STATE.midi_device_index,
-      notifier = select_midi_device(STATE.midi_device_index),
+      notifier = function(x)
+        select_midi_device(x)
+      end,
       tooltip = "MIDI device to send MIDI signals to."
     },
     vb:text {

--- a/gui.lua
+++ b/gui.lua
@@ -82,6 +82,9 @@ end
 
 function midi_list()
   print("midi_device_index: ", STATE.midi_device_index)
+  if STATE.midi_device_index > #renoise.Midi.available_output_devices() then
+    reset_midi_device_state()
+  end
   return vb:horizontal_aligner {
     margin = DEFAULT_MARGIN,
     spacing = 1,
@@ -94,7 +97,7 @@ function midi_list()
       width = "50%",
       items = renoise.Midi.available_output_devices(),
       value = STATE.midi_device_index,
-      notifier = select_midi_device,
+      notifier = select_midi_device(STATE.midi_device_index),
       tooltip = "MIDI device to send MIDI signals to."
     },
     vb:text {

--- a/midi.lua
+++ b/midi.lua
@@ -5,13 +5,21 @@ NOTE_OFF = 0x80
 ALL_NOTE_OFF_1 = 0xB0
 ALL_NOTE_OFF_2 = 0x7B
 
+
 -- get midi device name
 function select_midi_device(dev_index)
+  print("dev index:"..dev_index)
   STATE.midi_device = renoise.Midi.available_output_devices()[dev_index]
   STATE.midi_device_index = dev_index
   prefs:write("midi_device_index", dev_index)
   
   print("Selected device: "..STATE.midi_device)
+end
+
+-- get midi device object
+function get_midi_dev()
+  print("Getting device: "..STATE.midi_device)
+  return renoise.Midi.create_output_device(STATE.midi_device)
 end
 
 -- changes NOTE_ON and NOTE_OFF globals


### PR DESCRIPTION
…s no longer available.

I encountered an issue where my saved MIDI device was id 3 but that device was no longer plugged in. The tool would crash on startup since it was trying to render the view component of the selected item (3) that no longer existed. 

This change hooks into midi device callbacks and sets the midi device and stored preference to 1 if the current preference is no longer an option. 